### PR TITLE
resolve docstring todos

### DIFF
--- a/src/gax.ts
+++ b/src/gax.ts
@@ -84,8 +84,22 @@ export class RetryOptions {
   }
 }
 
-//TODO(coleleah): add docstring
-//TODO(galzahavi): add docstring info about getResumptionRequestFn
+/**
+ * Per-call configurable settings for working with retry-request
+ * See the repo README for more about the parameters
+ * https://github.com/googleapis/retry-request
+ * Will be deprecated in a future release. Only relevant to server streaming calls
+ * @typedef {Object} RetryOptions
+ * @property {boolean} objectMode - when true utilizes object mode in streams
+ * @property {request} request - the request to retry
+ * @property {number} noResponseRetries - number of times to retry on no response
+ * @property {number} currentRetryAttempt - what # retry attempt retry-request is on
+ * @property {Function} shouldRetryFn - determines whether to retry, returns a boolean
+ * @property {number} maxRetryDelay - maximum retry delay in seconds
+ * @property {number} retryDelayMultiplier - multiplier to increase the delay in between completion of failed requests
+ * @property {number} totalTimeout - total timeout in seconds
+ * @property {Function} getResumptionRequestFn - function used to determine stream resumption strategy. Returns the new request.
+ */
 export interface RetryRequestOptions {
   objectMode?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -230,7 +244,6 @@ export class CallSettings {
         retry.retryCodesOrShouldRetryFn !== undefined
       ) {
         // if it's an array of retry codes, make sure it has an element or check if it's a function
-        // TODO(coleleah): should we even support overriding retry codes or function w/ function or backwards compatible?
         if (
           (retry.retryCodesOrShouldRetryFn instanceof Array &&
             retry.retryCodesOrShouldRetryFn.length > 0) ||

--- a/src/streamingCalls/streaming.ts
+++ b/src/streamingCalls/streaming.ts
@@ -304,7 +304,7 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
     stream: CancellableStream,
     retry: RetryOptions,
     retryRequestOptions: RetryRequestOptions
-  ): undefined {
+  ): void {
     let enteredError = false;
     const eventsToForward = ['metadata', 'response', 'status', 'data'];
     eventsToForward.forEach(event => {

--- a/src/streamingCalls/streaming.ts
+++ b/src/streamingCalls/streaming.ts
@@ -304,9 +304,8 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
     stream: CancellableStream,
     retry: RetryOptions,
     retryRequestOptions: RetryRequestOptions
-  ): CancellableStream | undefined {
+  ): undefined {
     let enteredError = false;
-    const retryStream = this.stream; //TODO(coleleah): check the fact that this isn't used much
     const eventsToForward = ['metadata', 'response', 'status', 'data'];
     eventsToForward.forEach(event => {
       stream.on(event, this.emit.bind(this, event));
@@ -324,7 +323,6 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
         this.cancel();
       }
     });
-    return retryStream;
   }
 
   /**

--- a/test/test-application/src/index.ts
+++ b/test/test-application/src/index.ts
@@ -31,7 +31,7 @@ import {
   RetryOptions,
 } from 'google-gax';
 import stream = require('stream');
-
+//TODO(coleleah): tests with resumption strategy
 async function testShowcase() {
   const grpcClientOpts = {
     grpc,

--- a/test/unit/gax.ts
+++ b/test/unit/gax.ts
@@ -72,7 +72,6 @@ const RETRY_DICT = {
   code_c: 3,
 };
 
-//TODO (coleleah): double check this logic, add additional tests
 function expectRetryOptions(obj: gax.RetryOptions) {
   assert.ok(obj instanceof Object);
   ['retryCodesOrShouldRetryFn', 'backoffSettings'].forEach(k =>


### PR DESCRIPTION
Hi @galz10 , PTAL. Mainly looking for no outright errors, but two things to specifically check out
1. The return of `streamHandoffHelper` - is it that it returns a stream when there's a stream to retry, otherwise it doesn't return?
2. in `streamHandoffHelper` it seems like `retryStream` is set to `this.stream` and then isn't used again until the return - is that right, or should it actually be passed in another spot, like to the error handler? I think it's right, that you make a copy of the stream and return it, but I wanted to just double check